### PR TITLE
fix: cooldown for scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ See [docs](docs) for the user guide, description of the [design](docs/design.md)
 
 ## TODO
 
- - we need a "cooldown" strategy for scaling. With a CRD update, reconcile happens immediately, and the queue is likely to report it still needs scaling.
  - think about an experiment we could do, or should add other algorithms first?
  - Think about idea of shared jobs matrix that can go between members (advanced)
 

--- a/controllers/ensemble/ensemble_controller.go
+++ b/controllers/ensemble/ensemble_controller.go
@@ -95,11 +95,6 @@ func (r *EnsembleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.initJobsMatrix(ctx, &ensemble)
 	}
 
-	// Do we need to init the size lookup (where we keep current sizes of all members)
-	//if len(ensemble.Status.Sizes) == 0 {
-	//	return r.initSizesLookup(ctx, &ensemble)
-	//}
-
 	// Ensure we have the MiniCluster (get or create!)
 	// We only have MiniCluster now, but this design can be extended to others
 	for i, member := range ensemble.Spec.Members {
@@ -133,11 +128,8 @@ func (r *EnsembleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			if err != nil {
 				return result, err
 			}
-
 		}
 	}
-	// By the time we get here we have a Job + pods + config maps!
-	// What else do we want to do?
 	fmt.Println("      Ensemble is Ready!")
 
 	// If we've run updates across them, should requeue per preference of ensemble check frequency

--- a/controllers/ensemble/update.go
+++ b/controllers/ensemble/update.go
@@ -111,6 +111,18 @@ func (r *EnsembleReconciler) updateMiniClusterEnsemble(
 	// Are we scaling?
 	if decision.Action == algorithm.ScaleAction && decision.Scale > 0 {
 		if member.Type() == api.MiniclusterType {
+
+			// Issue a request to reset the counters for scaling first
+			// If this fails it's not the end of the world -it works
+			// without doing it, but better to avoid a possible race
+			in := pb.ActionRequest{
+				Member:    member.Type(),
+				Algorithm: algo.Name(),
+				Payload:   "[\"free_nodes\", \"waiting_periods\"]",
+				Action:    algorithm.ResetCounterAction,
+			}
+			response, _ := c.RequestAction(ctx, &in)
+			fmt.Println(response.Status)
 			return r.updateMiniClusterSize(ctx, ensemble, decision.Scale, name, idx)
 		}
 	}

--- a/examples/algorithms/workload/demand/README.md
+++ b/examples/algorithms/workload/demand/README.md
@@ -16,9 +16,7 @@ Here is what is going to happen:
 4. The jobs are submit on the MiniCluster, and the matrix is emptied.
 5. We proceed to monitor, scaling when conditions are met, downsizing when jobs are finishing, and terminating after that.
 
-Note that I've implemented up to 4, and just need to act on the metadata returned from the active queue (the count of jobs) as compared to the current MiniCluster size.
-If/when we hit a scaling or termination condition, we will do that, and then this algorithm (first draft) will be mostly done. If you are doing an example with scaling
-up and down, it's recommend to use actually different machines, e.g.,:
+If you are doing an example with scaling up and down, it's recommend to use actually different machines, e.g.,:
 
 ```bash
 GOOGLE_PROJECT=myproject

--- a/examples/kind-config.yaml
+++ b/examples/kind-config.yaml
@@ -1,9 +1,12 @@
 # Run this from this directory!
 # kind create cluster -f kind-config.yaml
-# kubectl apply -f ./examples/dist/flux-operator.yaml
+# kubectl apply -f ./examples/dist/ensemble-operator.yaml
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
+   - role: worker
+   - role: worker
+   - role: worker
    - role: control-plane
      extraMounts:
       - hostPath: "."

--- a/examples/tests/lammps/README.md
+++ b/examples/tests/lammps/README.md
@@ -1,0 +1,53 @@
+# LAMMPS
+
+You can read about the workload demand algorithm [here](https://github.com/converged-computing/ensemble-operator/blob/main/docs/algorithms.md#workoad-demand-of-consistent-sizes).
+For this example, you should create the provided kind cluster (4 nodes):
+
+```bash
+kind create cluster --config ./examples/dist/ensemble-operator.yaml
+```
+
+And install the operators:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/flux-framework/flux-operator/main/examples/dist/flux-operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/converged-computing/ensemble-operator/main/examples/dist/ensemble-operator.yaml
+```
+
+Here is what is going to happen:
+
+1. We define our jobs matrix in the [ensemble.yaml](ensemble.yaml). The jobs matrix is consistent across algorithms.
+2. For any algorithm, we first get a cluster status `StatusRequest`. We don't use it here aside from establishing communication. In the future if we return more metadata about the cluster it can be used to inform decision making.
+3. We then detect that the job matrix has outstanding jobs, and make an `ActionRequest` to "submit" the jobs.
+4. The jobs are submit on the MiniCluster, and the matrix is emptied.
+5. We proceed to monitor, scaling when conditions are met, downsizing when jobs are finishing, and terminating after that.
+
+## Usage
+
+Create the job. Note that this [ensemble.yaml](ensemble.yaml), for this algorithm type, requires you to submit jobs. It is retroactively going to adjust
+the queue based on what you submit. We also are going to rely on the algorithm to determine when to terminate the minicluster, so we add a sleep command
+to the end. Arguably this could be controlled (added) by the operator based on seeing the algorithm type, but this works for now.
+
+```bash
+kubectl apply -f ensemble.yaml
+```
+
+We can check both the gRPC sidecar and the operator to see if information is being received. Here is the
+sidecar (after setup steps):
+
+```bash
+# This is for the sidecar
+kubectl logs workload-demand-0-0-vfxxd -c api -f
+
+# This is for the ensemble operator
+$ kubectl logs workload-demand-0-0-d2trb -c api -f
+```
+
+You'll see:
+
+1. The jobs being submit at the onset
+2. Each request from the Ensemble Operator to get queue status
+3. When we reach the threshold of the queue not moving after 2 checks, we scale up
+4. The jobs complete and the ensemble terminates.
+
+

--- a/examples/tests/lammps/ensemble.yaml
+++ b/examples/tests/lammps/ensemble.yaml
@@ -1,23 +1,34 @@
 apiVersion: ensemble.flux-framework.org/v1alpha1
 kind: Ensemble
 metadata:
-  name: ensemble-sample
-spec:
+  name: workload-demand
+spec:  
   members:
   - sidecar:
       pullAlways: true
+      image: ghcr.io/converged-computing/ensemble-operator-api:rockylinux9
 
+    # Algorithm and options:
+    # terminateChecks says to terminate after 2 subsequent inactive status checks
+    algorithm:
+      name: workload-demand
+      options:
+        terminateChecks: 2
+        scaleUpChecks: 4
+
+    # I made these the size of the cluster so we trigger scaling at least once
     jobs:
-      - name: lammps
+      - name: lammps-2
         command: lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
+        count: 10
+        nodes: 1
 
     minicluster:
       spec:
-        size: 2
+        size: 1
         maxSize: 4
-        minSize: 2
-        tasks: 2
-    
+        minSize: 1
+
         # This is a list because a pod can support multiple containers
         containers:
         - image: ghcr.io/converged-computing/metric-lammps:latest

--- a/pkg/algorithm/algorithm.go
+++ b/pkg/algorithm/algorithm.go
@@ -17,6 +17,7 @@ var (
 	TerminateAction        = "terminate"
 	CompleteAction         = "complete"
 	ScaleAction            = "scale"
+	ResetCounterAction     = "resetCounter"
 	JobsMatrixUpdateAction = "updateJobsMatrix"
 
 	// Queue actions

--- a/python/ensemble_operator/server.py
+++ b/python/ensemble_operator/server.py
@@ -82,6 +82,19 @@ class EnsembleEndpoint(api.EnsembleOperatorServicer):
         """
         return self.increment_period("inactive_periods", increment, reset)
 
+    def reset_counter(self, payload):
+        """
+        Reset a named counter
+        """
+        global cache
+        payload = json.loads(payload)
+        if isinstance(payload, str):
+            payload = [payload]
+        for key in payload:
+            if key in cache:
+                print(f"Resetting counter for {key}")
+                cache[key] = 0
+
     def count_waiting_periods(self, current_waiting):
         """
         Count subsequent waiting periods that are == or greater than last count
@@ -203,6 +216,15 @@ class EnsembleEndpoint(api.EnsembleOperatorServicer):
             except Exception as e:
                 print(e)
                 status = ensemble_service_pb2.Response.ResultType.ERROR
+
+        # Reset a counter, typically after an update event
+        if request.action == "resetCounter":
+            try:
+                self.reset_counter(request.payload)
+            except Exception as e:
+                print(e)
+                status = ensemble_service_pb2.Response.ResultType.ERROR
+
         return ensemble_service_pb2.Response(status=status)
 
 


### PR DESCRIPTION
Problem: we currently can trigger scaling events one after the other because the reconcile happens immediately with the update for the CRD, and then the queue status has not changed (so it warrants another scaling event). 
Solution: With this strategy, we add a new action for a resetCounter event, and then reset both counters for scaling right before we issue the actual scale order. This works beautifully to have a scaling event, and then see the scaling counters back at 0, and then more reasonably see the next scaling event in 30 seconds to 1 minutes (unless the jobs finish and the cluster is terminated first!

This will close #8 